### PR TITLE
Commit README once it it rendered

### DIFF
--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -39,5 +39,6 @@ jobs:
         run: |
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add README.md
           git commit -m 'Re-build README.Rmd' || echo "No changes to commit"
           git push origin || echo "No changes to commit"


### PR DESCRIPTION
Related to https://github.com/easystats/easystats/issues/278. The GHA renders the README but doesn't commit the change, maybe this is why it isn't automatically updated?

