### PR TITLE
Show messages and errors in GHA for random order testing

### DIFF
--- a/.github/workflows/check-random-test-order.yaml
+++ b/.github/workflows/check-random-test-order.yaml
@@ -41,7 +41,7 @@ jobs:
           any_test_failures <- FALSE
           any_test_errors <- FALSE
           test_path <- function(path) {
-            report <- as.data.frame(testthat::test_file(path, reporter = "silent"))
+            report <- as.data.frame(testthat::test_file(path))
             has_test_failures <- any(report$failed == 1L)
             has_test_errors <- any(report$error == 1L)
             if (has_test_failures) {


### PR DESCRIPTION
It's harder to debug for now because it only prints "There are errors in this test file. Check the log" but there is no log? 

See e.g https://github.com/easystats/datawizard/actions/runs/4563508258/jobs/8052081246?pr=399