### PR TITLE
Simpler workflow for link rot

### DIFF
--- a/.github/workflows/check-link-rot.yaml
+++ b/.github/workflows/check-link-rot.yaml
@@ -19,10 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v2
-        with:
-          pandoc-version: "latest"
-
       - uses: r-lib/actions/setup-r@v2
         with:
           #r-version: "devel"

--- a/.github/workflows/check-link-rot.yaml
+++ b/.github/workflows/check-link-rot.yaml
@@ -19,18 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v2
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
         with:
-          #r-version: "devel"
-          use-public-rspm: true
-
-      - name: Run URL checker
-        run: |
-          install.packages(c("urlchecker", "cli"))
-          options(crayon.enabled = TRUE)
-          rotten_links <- urlchecker::url_check(progress = FALSE)
-          print(rotten_links)
-          if (length(rotten_links$URL) > 0L) {
-            cli::cli_abort("Some URLs are outdated and need to be updated.")
-          }
-        shell: Rscript {0}
+          fail: true

--- a/.github/workflows/check-link-rot.yaml
+++ b/.github/workflows/check-link-rot.yaml
@@ -28,18 +28,9 @@ jobs:
           #r-version: "devel"
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          pak-version: devel
-          upgrade: "TRUE"
-          cache-version: 2
-          dependencies: '"hard"'
-          extra-packages: |
-            any::rcmdcheck
-            r-lib/urlchecker
-
       - name: Run URL checker
         run: |
+          install.packages(c("urlchecker", "cli"))
           options(crayon.enabled = TRUE)
           rotten_links <- urlchecker::url_check(progress = FALSE)
           print(rotten_links)

--- a/.github/workflows/check-spelling.yaml
+++ b/.github/workflows/check-spelling.yaml
@@ -15,10 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v2
-        with:
-          pandoc-version: "latest"
-
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true


### PR DESCRIPTION
Uses https://github.com/lycheeverse/lychee-action

Takes 5s instead of 1m30 on average (and detects a link failure in `CONTIRBUTING.md` that was unnoticed)