### PR TITLE
Ignore `correlation` before R 4.1.0

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -73,6 +73,7 @@ jobs:
             distributional=?ignore-before-r=4.2.0
             Hmisc=?ignore-before-r=4.2.0
             mediation=?ignore-before-r=4.2.0
+            pbkrtest=?ignore-before-r=4.2.0
             serp=?ignore-before-r=4.1.0
             VGAM=?ignore-before-r=4.1.0
             glmmTMB=?ignore-before-r=4.1.0
@@ -93,12 +94,12 @@ jobs:
             ICSOutlier=?ignore-before-r=4.1.0
             ICS=?ignore-before-r=4.1.0
             ivreg=?ignore-before-r=4.1.0
-            pbkrtest=?ignore-before-r=4.2.0
             AER=?ignore-before-r=4.1.0
             WRS2=?ignore-before-r=4.1.0
             tinytable=?ignore-before-r=4.1.0
             srvyr=?ignore-before-r=4.1.0
             survey=?ignore-before-r=4.1.0
+            correlation=?ignore-before-r=4.1.0
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
https://github.com/easystats/easystats/pull/408#issuecomment-2696426258

Tests in `datawizard` fail on 4.0 because `correlation` now depends on R >= 4.1.0.

cc @IndrajeetPatil @strengejacke 