### PR TITLE
R CMD check: Do not error on `NOTE`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -128,7 +128,7 @@ jobs:
         with:
           upload-snapshots: true
           upload-results: true
-          error-on: 'ifelse(getRversion() > "4.3", "note", "warning")'
+          error-on: '"warning"'
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
           _R_CHECK_CRAN_INCOMING_: false


### PR DESCRIPTION
It's just annoying to have a workflow failing because some packages are not available, even if we handle that correctly in tests and examples: https://github.com/easystats/datawizard/actions/runs/15365889923/job/43238743343

Note that this only errors on 4.3.3, it doesn't on 4.2.3 while we get the same  `NOTE`: https://github.com/easystats/datawizard/actions/runs/15365889923/job/43238743347