### PR TITLE
remove coalesce_linter

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -46,6 +46,7 @@ jobs:
           options(crayon.enabled = TRUE)
           library(lintr)
           lint_package(linters = all_linters(
+            coalesce_linter = NULL,
             absolute_path_linter = NULL,
             cyclocomp_linter(40L),
             if_not_else_linter(exceptions = character(0L)),

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,6 +37,7 @@ jobs:
           options(crayon.enabled = TRUE)
           library(lintr)
           lint_package(linters = all_linters(
+            coalesce_linter = NULL,
             absolute_path_linter = NULL,
             cyclocomp_linter(40L),
             if_not_else_linter(exceptions = character(0L)),


### PR DESCRIPTION
remove coalesce_linter because the %||% operator only appears in R version >= 4.4.0