### PR TITLE
fix: allow update workflow PRs to trigger CI

### DIFF
--- a/.github/workflows/update-to-latest-easystats.yaml
+++ b/.github/workflows/update-to-latest-easystats.yaml
@@ -5,6 +5,10 @@
 
 on:
   workflow_call:
+    secrets:
+      EASYSTATS_BOT_TOKEN:
+        required: false
+        description: "Token used to create pull requests that should trigger CI workflows."
 
 jobs:
   update-to-latest-easystats:
@@ -43,7 +47,7 @@ jobs:
         #if: ${{ steps.update_description.outputs.changed }}
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.EASYSTATS_BOT_TOKEN || github.token }}
           base: main
           branch: desc-${{ github.ref_name }}-${{ github.job }}
           branch-suffix: timestamp

--- a/README.Rmd
+++ b/README.Rmd
@@ -102,6 +102,12 @@ name: test-coverage
 | :------------------------------- | :------------------------------------------------------------------------------ |
 | update-to-latest-easystats.yaml  | Creates a PR to bump all `easystats` dependencies to their latest CRAN version. |
 
+The `update-to-latest-easystats.yaml` workflow can receive an optional
+`EASYSTATS_BOT_TOKEN` secret. Pass a fine-grained PAT or GitHub App token if the
+pull requests created by this workflow should trigger the usual `pull_request`
+or `push` checks. If this secret is not supplied, the workflow falls back to the
+default `GITHUB_TOKEN`.
+
 ## Acknowledgments
 
 These workflows are based on [r-lib/actions](https://github.com/r-lib/actions). Huge thanks to the creators, maintainers, and contributors to that repo!!

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ name: test-coverage
 |:---|:---|
 | update-to-latest-easystats.yaml | Creates a PR to bump all `easystats` dependencies to their latest CRAN version. |
 
+The `update-to-latest-easystats.yaml` workflow can receive an optional
+`EASYSTATS_BOT_TOKEN` secret. Pass a fine-grained PAT or GitHub App
+token if the pull requests created by this workflow should trigger the
+usual `pull_request` or `push` checks. If this secret is not supplied,
+the workflow falls back to the default `GITHUB_TOKEN`.
+
 ## Acknowledgments
 
 These workflows are based on


### PR DESCRIPTION
Summary

Let the reusable `update-to-latest-easystats` workflow use an optional caller-supplied token when it creates dependency update PRs.

Thanks to maintainers

Thanks for maintaining these shared workflows. The issue report and `datawizard#640` example made the failure mode clear.

Issue or motivation

Closes #83. PRs created with the default `GITHUB_TOKEN` do not trigger the usual `pull_request` or `push` workflows, so the automated dependency-update PR can appear without CI checks.

Root cause

The workflow always passed `secrets.GITHUB_TOKEN` to `peter-evans/create-pull-request`. GitHub suppresses most workflow events caused by `GITHUB_TOKEN`, which prevents the generated PR from starting the package CI.

Change

- Declare an optional `EASYSTATS_BOT_TOKEN` secret on the reusable workflow.
- Use that token for `create-pull-request` when callers provide it, with `github.token` as the fallback to preserve current behavior.
- Document the optional secret in `README.Rmd` and regenerate `README.md`.

Tests

- `actionlint .github/workflows/update-to-latest-easystats.yaml`
- `Rscript -e 'rmarkdown::render("README.Rmd", quiet = TRUE)'`
- `R CMD build .`
- `R CMD check --no-manual workflows_0.1.0.tar.gz`

`R CMD check` reports the same pre-existing 1 WARNING and 2 NOTEs on `origin/main` and on this branch: the CC0 license string, `LICENSE` top-level note, and `.github` hidden-directory note.

Scope

This only changes the token used to create the automated dependency PR and the README note for callers. It does not change the dependency-update logic, branch naming, PR title/body, labels, or any general-purpose workflow.
